### PR TITLE
Add Gemfile, specify turn as a development dependency in the gemspec.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.gem
 .rbenv-version
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source :rubygems
+
+gemspec

--- a/Readme.md
+++ b/Readme.md
@@ -37,4 +37,5 @@ Have fun!
 
 ## Running Tests
 
-    $ turn test
+    $ bundle install
+    $ bundle exec turn test

--- a/netrc.gemspec
+++ b/netrc.gemspec
@@ -12,4 +12,6 @@ Gem::Specification.new do |gem|
   gem.description = "This library can read and update netrc files, preserving formatting including comments and whitespace."
 
   gem.files = %x{ git ls-files }.split("\n").select { |d| d =~ %r{^(Readme.md|data/|lib/|test/)} }
+
+  gem.add_development_dependency "turn"
 end


### PR DESCRIPTION
This lets one clone the repo and `bundle install` without having to think about any necessary dependencies.
