### PR TITLE
Prevent file permission check on Windows

### DIFF
--- a/lib/netrc.rb
+++ b/lib/netrc.rb
@@ -1,19 +1,21 @@
+require 'rbconfig'
+
 class Netrc
   VERSION = "0.7.4"
-  CYGWIN  = RUBY_PLATFORM =~ /cygwin/i
-  WINDOWS = RUBY_PLATFORM =~ /win32|mingw32/i
+  WINDOWS = RbConfig::CONFIG["host_os"] =~ /mswin|mingw|cygwin/
+  CYGWIN  = RbConfig::CONFIG["host_os"] =~ /cygwin/
 
   def self.default_path
-    if WINDOWS
+    if WINDOWS && !CYGWIN
       File.join(ENV['USERPROFILE'].gsub("\\","/"), "_netrc")
     else
-      File.join(ENV["HOME"], ".netrc")
+      File.join((ENV["HOME"] || "./"), ".netrc")
     end
   end
 
   def self.check_permissions(path)
     perm = File.stat(path).mode & 0777
-    if perm != 0600 && !(CYGWIN) && !(WINDOWS)
+    if perm != 0600 && !(WINDOWS)
       raise Error, "Permission bits for '#{path}' should be 0600, but are "+perm.to_s(8)
     end
   end

--- a/test/test_netrc.rb
+++ b/test/test_netrc.rb
@@ -3,11 +3,18 @@ require 'test/unit'
 require 'fileutils'
 
 require File.expand_path("#{File.dirname(__FILE__)}/../lib/netrc")
+require "rbconfig"
 
 class TestNetrc < Test::Unit::TestCase
+
   def setup
     File.chmod(0600, "data/sample.netrc")
     File.chmod(0644, "data/permissive.netrc")
+  end
+
+  # see http://stackoverflow.com/questions/4871309/what-is-the-correct-way-to-detect-if-ruby-is-running-on-windows
+  def is_windows?
+    RbConfig::CONFIG["host_os"] =~ /mswin|mingw|cygwin/
   end
 
   def test_parse_empty
@@ -36,8 +43,15 @@ class TestNetrc < Test::Unit::TestCase
 
   def test_permission_error
     Netrc.read("data/permissive.netrc")
-    assert false, "Should raise an error if permissions are wrong."
+    assert false, "Should raise an error if permissions are wrong on a non-windows system." unless is_windows?
   rescue Netrc::Error
+  end
+
+  def test_permission_error_windows
+    def Netrc.is_windows?; true end
+    Netrc.read("data/permissive.netrc")
+  rescue Netrc::Error
+    assert false, "Should not raise an error if permissions are wrong on a non-windows system." unless is_windows?
   end
 
   def test_round_trip
@@ -98,7 +112,7 @@ class TestNetrc < Test::Unit::TestCase
     FileUtils.rm_f("/tmp/created.netrc")
     n = Netrc.read("/tmp/created.netrc")
     n.save
-    assert_equal(0600, File.stat("/tmp/created.netrc").mode & 0777)
+    assert_equal(0600, File.stat("/tmp/created.netrc").mode & 0777) unless is_windows?
   end
 
   def test_encrypted_roundtrip
@@ -111,4 +125,15 @@ class TestNetrc < Test::Unit::TestCase
       assert_equal(["a", "b"], Netrc.read("/tmp/test.netrc.gpg")["m"])
     end
   end
+
+  def test_missing_environment
+    nil_home = nil
+    ENV["HOME"], nil_home = nil_home, ENV["HOME"]
+    n = Netrc.read
+    assert_equal(nil, n["x"])
+  ensure
+    ENV["HOME"], nil_home = nil_home, ENV["HOME"]
+  end
+
+
 end


### PR DESCRIPTION
geemus/netrc#9

I also addressed another bug I encountered today. If ENV["HOME"] isn't set, File.join fails while trying to locate the ~/.netrc file.
