### PR TITLE
Return Entry objects from []

### DIFF
--- a/lib/netrc.rb
+++ b/lib/netrc.rb
@@ -131,7 +131,7 @@ class Netrc
 
   def [](k)
     if item = @data.detect {|datum| datum[1] == k}
-      [item[3], item[5]]
+      Entry.new(item[3], item[5])
     end
   end
 
@@ -189,6 +189,10 @@ class Netrc
         datum
       end
     end.join
+  end
+
+  Entry = Struct.new(:login, :password) do
+    alias to_ary to_a
   end
 
 end

--- a/test/test_netrc.rb
+++ b/test/test_netrc.rb
@@ -96,7 +96,7 @@ class TestNetrc < Test::Unit::TestCase
   def test_set_get
     n = Netrc.read("data/sample.netrc")
     n["m"] = "a", "b"
-    assert_equal(["a", "b"], n["m"])
+    assert_equal(["a", "b"], n["m"].to_a)
   end
 
   def test_add
@@ -133,7 +133,7 @@ class TestNetrc < Test::Unit::TestCase
     n = Netrc.read("data/sample.netrc")
     n.new_item_prefix = "# added\n"
     n["x"] = "a", "b"
-    assert_equal(["a", "b"], n["x"])
+    assert_equal(["a", "b"], n["x"].to_a)
   end
 
   def test_get_missing
@@ -176,5 +176,37 @@ class TestNetrc < Test::Unit::TestCase
     ENV["HOME"], nil_home = nil_home, ENV["HOME"]
   end
 
+  def test_read_entry
+    entry = Netrc.read("data/sample.netrc")['m']
+    assert_equal 'l', entry.login
+    assert_equal 'p', entry.password
+
+    # hash-style
+    assert_equal 'l', entry[:login]
+    assert_equal 'p', entry[:password]
+  end
+
+  def test_write_entry
+    n = Netrc.read("data/sample.netrc")
+    entry = n['m']
+    entry.login    = 'new_login'
+    entry.password = 'new_password'
+    n['m'] = entry
+    assert_equal(['new_login', 'new_password'], n['m'].to_a)
+  end
+
+  def test_entry_splat
+    e = Netrc::Entry.new("user", "pass")
+    user, pass = *e
+    assert_equal("user", user)
+    assert_equal("pass", pass)
+  end
+
+  def test_entry_implicit_splat
+    e = Netrc::Entry.new("user", "pass")
+    user, pass = e
+    assert_equal("user", user)
+    assert_equal("pass", pass)
+  end
 
 end


### PR DESCRIPTION
This makes it possible to read login and password like this:

``` ruby
  netrc = Netrc.read
  entry = netrc['machine']
  login = entry.login
  pass  = entry.password
```

Through the use of a lightly-tweaked Struct, the Entry object behaves almost identically to the old arrays, including implicit splatting when it is on the right side of an assignment:

``` ruby
  netrc = Netrc.read
  entry = netrc['machine']
  login, pass = entry
```

As a result, the old tests still pass with very minimal changes. However, I can't guarantee that this won't break some usage of the library somewhere. E.g. comparison to an Array might return `false` where once it returned `true`:

``` ruby
  ['user', 'pass'] == netrc['machine'] # => false
```
