### PR TITLE
fix undefined variable path

### DIFF
--- a/lib/netrc.rb
+++ b/lib/netrc.rb
@@ -200,7 +200,7 @@ class Netrc
         gpg.close_write
         gpg.read
       end
-      raise Error.new("Encrypting #{path} failed.") unless $?.success?
+      raise Error.new("Encrypting #{@path} failed.") unless $?.success?
       File.open(@path, 'w', 0600) {|file| file.print(e)}
     else
       File.open(@path, 'w', 0600) {|file| file.print(unparse)}


### PR DESCRIPTION
```
  1) Error:
test_encrypted_roundtrip(TestNetrc):
NameError: undefined local variable or method `path' for #<Netrc:0x86332d0>
    /tmp/B.50378a16-d873-429b-a943-a1cebd9f8449/BUILD/netrc-0.7.7/lib/netrc.rb:176:in `save'
    /tmp/B.50378a16-d873-429b-a943-a1cebd9f8449/BUILD/netrc-0.7.7/test/test_netrc.rb:164:in `test_encrypted_roundtrip'
    /usr/share/ruby/2.0/minitest/unit.rb:1301:in `run'
    /usr/share/ruby/2.0/test/unit/testcase.rb:17:in `run'
    /usr/share/ruby/2.0/minitest/unit.rb:919:in `block in _run_suite'
    /usr/share/ruby/2.0/minitest/unit.rb:912:in `map'
    /usr/share/ruby/2.0/minitest/unit.rb:912:in `_run_suite'
    /usr/share/ruby/2.0/test/unit.rb:657:in `block in _run_suites'
    /usr/share/ruby/2.0/test/unit.rb:655:in `each'
    /usr/share/ruby/2.0/test/unit.rb:655:in `_run_suites'
    /usr/share/ruby/2.0/minitest/unit.rb:867:in `_run_anything'
    /usr/share/ruby/2.0/minitest/unit.rb:1060:in `run_tests'
    /usr/share/ruby/2.0/minitest/unit.rb:1047:in `block in _run'
    /usr/share/ruby/2.0/minitest/unit.rb:1046:in `each'
    /usr/share/ruby/2.0/minitest/unit.rb:1046:in `_run'
    /usr/share/ruby/2.0/minitest/unit.rb:1035:in `run'
    /usr/share/ruby/2.0/test/unit.rb:21:in `run'
    /usr/share/ruby/2.0/test/unit.rb:774:in `run'
    /usr/share/ruby/2.0/test/unit.rb:834:in `run'
    /usr/share/ruby/2.0/test/unit.rb:838:in `run'
    /usr/bin/testrb:3:in `<main>'
```
