### PR TITLE
Be less restrictive on netrc permissions

### DIFF
--- a/lib/netrc.rb
+++ b/lib/netrc.rb
@@ -29,8 +29,9 @@ class Netrc
 
   def self.check_permissions(path)
     perm = File.stat(path).mode & 0777
-    if perm != 0600 && !(WINDOWS) && !(Netrc.config[:allow_permissive_netrc_file])
-      raise Error, "Permission bits for '#{path}' should be 0600, but are "+perm.to_s(8)
+    check_bits = perm & 0077
+    if check_bits != 0 && !(WINDOWS) && !(Netrc.config[:allow_permissive_netrc_file])
+      raise Error, "Permission bits for '#{path}' should be private, but are "+perm.to_s(8)
     end
   end
 


### PR DESCRIPTION
My `.netrc` permission bits are `0400`, which shouldn't be a problem.  However, the test below fails.  It seems to be too restrictive.

    def self.check_permissions(path)
        perm = File.stat(path).mode & 0777
        if perm != 0600 && !(WINDOWS) && !(Netrc.config[:allow_permissive_netrc_file])
          raise Error, "Permission bits for '#{path}' should be 0600, but are "+perm.to_s(8)
        end
      end

All that's really required is `.netrc` is not world/group accessible.