### PR TITLE
Migrate to MiniTest

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,4 +47,4 @@ Have fun!
 ## Running Tests
 
     $ bundle install
-    $ bundle exec turn test
+    $ bundle ruby -e 'Dir.glob "./test/**/test_*.rb", &method(:require)'

--- a/netrc.gemspec
+++ b/netrc.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |gem|
 
   gem.files = %x{ git ls-files }.split("\n").select { |d| d =~ %r{^(changelog.txt|LICENSE|Readme.md|data/|lib/|test/)} }
 
-  gem.add_development_dependency "turn"
+  gem.add_development_dependency "minitest"
 end

--- a/test/test_lex.rb
+++ b/test/test_lex.rb
@@ -1,9 +1,9 @@
 $VERBOSE = true
-require 'test/unit'
+require 'minitest/autorun'
 
 require File.expand_path("#{File.dirname(__FILE__)}/../lib/netrc")
 
-class TestLex < Test::Unit::TestCase
+class TestLex < Minitest::Test
   def test_lex_empty
     t = Netrc.lex([])
     assert_equal([], t)

--- a/test/test_netrc.rb
+++ b/test/test_netrc.rb
@@ -1,11 +1,11 @@
 $VERBOSE = true
-require 'test/unit'
+require 'minitest/autorun'
 require 'fileutils'
 
 require File.expand_path("#{File.dirname(__FILE__)}/../lib/netrc")
 require "rbconfig"
 
-class TestNetrc < Test::Unit::TestCase
+class TestNetrc < Minitest::Test
 
   def setup
     Dir.glob('data/*.netrc').each{|f| File.chmod(0600, f)}

--- a/test/test_parse.rb
+++ b/test/test_parse.rb
@@ -1,9 +1,9 @@
 $VERBOSE = true
-require 'test/unit'
+require 'minitest/autorun'
 
 require File.expand_path("#{File.dirname(__FILE__)}/../lib/netrc")
 
-class TestParse < Test::Unit::TestCase
+class TestParse < Minitest::Test
   def test_parse_empty
     pre, items = Netrc.parse([])
     assert_equal("", pre)


### PR DESCRIPTION
The test-unit wrapper shipped in Ruby 2.1 is deprecated => use just MiniTest.