### PR TITLE
fixing missing_env test. adding readable check

### DIFF
--- a/lib/netrc.rb
+++ b/lib/netrc.rb
@@ -58,7 +58,9 @@ class Netrc
         raise Error.new("Decrypting #{path} failed.") unless $?.success?
       end
     else
-      File.read(path)
+      raise Errornew("'#{path}' does not exist") unless File.readable?(path)
+
+      File.read(path) 
     end
     new(path, parse(lex(data.lines.to_a)))
   rescue Errno::ENOENT

--- a/test/test_netrc.rb
+++ b/test/test_netrc.rb
@@ -200,7 +200,8 @@ class TestNetrc < Minitest::Test
   def test_missing_environment
     nil_home = nil
     ENV["HOME"], nil_home = nil_home, ENV["HOME"]
-    assert_equal File.join(Dir.pwd, '.netrc'), Netrc.default_path
+    default = Dir.respond_to?(:home) ? Dir.home : Dir.pwd
+    assert_equal File.join(default, '.netrc'), Netrc.default_path
   ensure
     ENV["HOME"], nil_home = nil_home, ENV["HOME"]
   end


### PR DESCRIPTION
Fixing a gnarly situation if your sys admin places a .netrc file in the right place, but you don't have permissions to read it.  Since the file is unreadable, it shouldn't be considered for configuration.