### PR TITLE
Respect NETRC environment variable

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,8 +13,11 @@ If the file doesn't exist, Netrc.read will return an empty object. If
 the filename ends in ".gpg", it will be decrypted using
 [GPG](http://www.gnupg.org/).
 
-Read the user's default netrc file. On Unix: `$HOME/.netrc`.
-On Windows: `%HOME%\_netrc`, `%HOMEDRIVE%%HOMEPATH%\_netrc`, or `%USERPROFILE%\_netrc` (whichever is set first).
+Read the user's default netrc file.
+
+**On Unix:** `$NETRC/.netrc` or `$HOME/.netrc` (whichever is set first).
+
+**On Windows:** `%NETRC%\_netrc`, `%HOME%\_netrc`, `%HOMEDRIVE%%HOMEPATH%\_netrc`, or `%USERPROFILE%\_netrc` (whichever is set first).
 
     n = Netrc.read
 
@@ -47,4 +50,4 @@ Have fun!
 ## Running Tests
 
     $ bundle install
-    $ bundle ruby -e 'Dir.glob "./test/**/test_*.rb", &method(:require)'
+    $ bundle exec ruby -e 'Dir.glob "./test/**/test_*.rb", &method(:require)'

--- a/lib/netrc.rb
+++ b/lib/netrc.rb
@@ -8,7 +8,7 @@ class Netrc
   CYGWIN  = RbConfig::CONFIG["host_os"] =~ /cygwin/
 
   def self.default_path
-    File.join(home_path, netrc_filename)
+    File.join(ENV['NETRC'] || home_path, netrc_filename)
   end
 
   def self.home_path
@@ -18,7 +18,7 @@ class Netrc
       home ||= File.join(ENV['HOMEDRIVE'], ENV['HOMEPATH']) if ENV['HOMEDRIVE'] && ENV['HOMEPATH']
       home ||= ENV['USERPROFILE']
       # XXX: old stuff; most likely unnecessary
-      home = home.gsub("\\", "/") unless home.nil?
+      home = home.tr("\\", "/") unless home.nil?
     end
 
     (home && File.readable?(home)) ? home : Dir.pwd

--- a/test/test_netrc.rb
+++ b/test/test_netrc.rb
@@ -205,6 +205,13 @@ class TestNetrc < Minitest::Test
     ENV["HOME"], nil_home = nil_home, ENV["HOME"]
   end
 
+  def test_netrc_environment_variable
+    ENV["NETRC"] = File.join(Dir.pwd, 'data')
+    assert_equal File.join(Dir.pwd, 'data', '.netrc'), Netrc.default_path
+  ensure
+    ENV.delete("NETRC")
+  end
+
   def test_read_entry
     entry = Netrc.read("data/sample.netrc")['m']
     assert_equal 'l', entry.login


### PR DESCRIPTION
According GNU docs, lets respect `NETRC` env.
This patch will change resolution process for `.netrc` file directory.

**Unix:** `$NETRC/.netrc` > `$HOME/.netrc`
**Windows:** `%NETRC%\_netrc` > `%HOME%\_netrc` > `%HOMEDRIVE%%HOMEPATH%\_netrc` > `%USERPROFILE%\_netrc`