### PR TITLE
Fix Netrc.parse for entries without a login or password field

### DIFF
--- a/data/sample_multi_without_logins.netrc
+++ b/data/sample_multi_without_logins.netrc
@@ -1,0 +1,10 @@
+# this is my netrc with multiple machines
+machine m
+  password pm
+
+machine n
+  password pn
+
+machine o
+  login lo
+  password po

--- a/lib/netrc.rb
+++ b/lib/netrc.rb
@@ -152,16 +152,23 @@ class Netrc
         cur << ts.take
       end
 
-      if ts.include?('login')
-        cur << ts.readto{|t| t == "login"} + ts.take + ts.readto{|t| ! skip?(t)}
-        cur << ts.take
+      login = [nil, nil]
+      password = [nil, nil]
+
+      2.times do
+        t1 = ts.readto{|t| t == "login" || t == "password" || t == "machine" || t == "default"}
+
+        if ts[0] == "login"
+          login = [t1 + ts.take + ts.readto{|t| ! skip?(t)}, ts.take]
+        elsif ts[0] == "password"
+          password = [t1 + ts.take + ts.readto{|t| ! skip?(t)}, ts.take]
+        else
+          ts.unshift(t1)
+        end
       end
 
-      if ts.include?('password')
-        cur << ts.readto{|t| t == "password"} + ts.take + ts.readto{|t| ! skip?(t)}
-        cur << ts.take
-      end
-
+      cur += login
+      cur += password
       cur << ts.readto{|t| t == "machine" || t == "default"}
 
       item << cur

--- a/test/test_netrc.rb
+++ b/test/test_netrc.rb
@@ -42,6 +42,8 @@ class TestNetrc < Minitest::Test
             "m",
             "\n  login ",
             "l",
+            nil,
+            nil,
             " # this is my username\n"]]
     assert_equal(exp, items)
   end
@@ -51,6 +53,8 @@ class TestNetrc < Minitest::Test
     assert_equal("# this is my password netrc\n", pre)
     exp = [["machine ",
             "m",
+            nil,
+            nil,
             "\n  password ",
             "p",
             " # this is my password\n"]]
@@ -222,6 +226,26 @@ class TestNetrc < Minitest::Test
     assert_equal 'p', entry[:password]
   end
 
+  def test_read_entry_without_login
+    entry = Netrc.read("data/password.netrc")['m']
+    assert_nil entry.login
+    assert_equal 'p', entry.password
+
+    # hash-style
+    assert_nil entry[:login]
+    assert_equal 'p', entry[:password]
+  end
+
+  def test_read_entry_without_password
+    entry = Netrc.read("data/login.netrc")['m']
+    assert_equal 'l', entry.login
+    assert_nil entry.password
+
+    # hash-style
+    assert_equal 'l', entry[:login]
+    assert_nil entry[:password]
+  end
+
   def test_write_entry
     n = Netrc.read("data/sample.netrc")
     entry = n['m']
@@ -269,5 +293,12 @@ class TestNetrc < Minitest::Test
     netrc = Netrc.read('data/default_only.netrc')
     assert_equal(['ld', 'pd'], netrc['m'].to_a)
     assert_equal(['ld', 'pd'], netrc['other'].to_a)
+  end
+
+  def test_multi_without_logins
+    netrc = Netrc.read('data/sample_multi_without_logins.netrc')
+    assert_equal([nil, 'pm'], netrc['m'].to_a)
+    assert_equal([nil, 'pn'], netrc['n'].to_a)
+    assert_equal(['lo', 'po'], netrc['o'].to_a)
   end
 end


### PR DESCRIPTION
Currently the gem breaks if either the login or password fields are missing. For example:

```ruby
require 'netrc'

input = %{
machine example.com
  password foo
machine api.github.com
  password bar
machine api.example.org
  login alice
  password baz
}

netrc = Netrc.new('.netrc', Netrc.parse(Netrc.lex(input.lines.to_a)))

p netrc['example.com'] # returns Netrc::Entry for api.example.org
p netrc['api.github.com'] # returns nil
p netrc['api.example.org'] # returns nil
```

The root cause is the parsing algorithm in Netrc.parse which matches tokens greedily, swallowing up multiple entries until the "login" token is found.

This pull request changes the algorithm to allow the login or password fields to be nil, and adds some tests for coverage. Also fixes https://github.com/heroku/netrc/issues/14