### PR TITLE
Fix Minitest deprecation warning for assert_nil

### DIFF
--- a/test/test_netrc.rb
+++ b/test/test_netrc.rb
@@ -166,7 +166,7 @@ class TestNetrc < Minitest::Test
 
   def test_get_missing
     n = Netrc.read("data/sample.netrc")
-    assert_equal(nil, n["x"])
+    assert_nil(n["x"])
   end
 
   def test_save


### PR DESCRIPTION
DEPRECATED: Use assert_nil if expecting nil from test/test_netrc.rb:169. This will fail in Minitest 6.