### PR TITLE
fixes #44 (unit tests): silence deprecation warning "This will fail in Minitest 6"

### DIFF
--- a/test/test_netrc.rb
+++ b/test/test_netrc.rb
@@ -166,7 +166,7 @@ class TestNetrc < Minitest::Test
 
   def test_get_missing
     n = Netrc.read("data/sample.netrc")
-    assert_equal(nil, n["x"])
+    assert_nil(n["x"])
   end
 
   def test_save


### PR DESCRIPTION
Switch a single nil-checking `assert_equal(...)` with the equivalent `assert_nil(...)`
