### PR TITLE
fixes #48: avoid choking when ~/.netrc perms are 0400

### DIFF
--- a/data/restrictive0000.netrc
+++ b/data/restrictive0000.netrc
@@ -1,0 +1,4 @@
+# this is my netrc
+machine m
+  login l # this is my username
+  password p

--- a/data/restrictive0400.netrc
+++ b/data/restrictive0400.netrc
@@ -1,0 +1,4 @@
+# this is my netrc
+machine m
+  login l # this is my username
+  password p

--- a/data/restrictive0600.netrc
+++ b/data/restrictive0600.netrc
@@ -1,0 +1,4 @@
+# this is my netrc
+machine m
+  login l # this is my username
+  password p

--- a/lib/netrc.rb
+++ b/lib/netrc.rb
@@ -42,8 +42,16 @@ class Netrc
 
   def self.check_permissions(path)
     perm = File.stat(path).mode & 0777
-    if perm != 0600 && !(WINDOWS) && !(Netrc.config[:allow_permissive_netrc_file])
-      raise Error, "Permission bits for '#{path}' should be 0600, but are "+perm.to_s(8)
+
+    # Regardless of whether or not the caller has requested that permissive
+    # perms be allowed on the netrc file, we baulk if the perms are too
+    # restrictive; we need to be able to read the file.
+    unless File.stat(path).readable?
+      raise Error, "File '#{path}' is not readable; perms are "+perm.to_s(8)
+    end
+
+    if perm != 0400 && perm != 0600 && !(WINDOWS) && !(Netrc.config[:allow_permissive_netrc_file])
+      raise Error, "Permission bits for '#{path}' should be 0600 (or 0400), but are "+perm.to_s(8)
     end
   end
 


### PR DESCRIPTION
The code already took measures to prevent overly-permissive perms, but only
allowed for 0600, which broke a real world use case. The code will now accept
0400, as well, but not 0000. Unit tests included.