### PR TITLE
fixes #51: silence "ambiguous first argument" warning in unit test

### DIFF
--- a/test/test_netrc.rb
+++ b/test/test_netrc.rb
@@ -121,7 +121,7 @@ class TestNetrc < Minitest::Test
     Netrc.read("data/restrictive0000.netrc")
     assert false, "Should raise an error if permissions do not include S_IRUSR (00400) u+r (readable by owner) on a non-windows system."
   rescue Netrc::Error => ex
-    assert_match /is not readable/, ex.message, "Exception should indicate \"is not readable\" (got: #{ex.message})"
+    assert_match(/is not readable/, ex.message, "Exception should indicate \"is not readable\" (got: #{ex.message})")
     assert true, ""
   ensure
     Netrc.send(:remove_const, :WINDOWS)


### PR DESCRIPTION
Full warning from the `test_error_restrictive0000_netrc_file_perms` test was:
```
    /path/to/test/test_netrc.rb:124: warning: ambiguous first argument; put parentheses or a space even after `/' operator
```