### PR TITLE
Make `NETRC` env var handling aligned with GNU inetutils

### DIFF
--- a/lib/netrc.rb
+++ b/lib/netrc.rb
@@ -9,7 +9,16 @@ class Netrc
   CYGWIN  = RbConfig::CONFIG["host_os"] =~ /cygwin/
 
   def self.default_path
-    File.join(ENV['NETRC'] || home_path, netrc_filename)
+    if not ENV['NETRC']
+      File.join(home_path, netrc_filename)
+    elsif File.directory?(ENV['NETRC'])
+      # Backward compatible behavior where `[\._]netrc` gets appended to the `NETRC` env var if it points to a directory
+      File.join(ENV['NETRC'], netrc_filename)
+    else
+      # Behavior identical to GNU inetutils where `NETRC` env var used as is.
+      # See https://github.com/guillemj/inetutils/blob/master/ftp/ruserpass.c#L120-L132 for more info
+      ENV['NETRC']
+    end
   end
 
   def self.home_path

--- a/test/netrc_test.rb
+++ b/test/netrc_test.rb
@@ -309,8 +309,17 @@ class TestNetrc < Minitest::Test
   end
 
   def test_netrc_environment_variable
-    ENV["NETRC"] = File.join(Dir.pwd, 'data')
-    assert_equal File.join(Dir.pwd, 'data', '.netrc'), Netrc.default_path
+    [
+      # Backward compatible behavior where `[\._]netrc` gets appended to the `NETRC` env var if it points to a directory
+      [File.join(Dir.pwd, 'data'), File.join(Dir.pwd, 'data', '.netrc')],
+      # Behavior identical to GNU inetutils where `NETRC` env var used as is.
+      # See https://github.com/guillemj/inetutils/blob/master/ftp/ruserpass.c#L120-L132 for more info
+      [File.join(Dir.pwd, 'data', '.netrc'), File.join(Dir.pwd, 'data', '.netrc')],
+      [File.join(Dir.pwd, 'data', '.xyz'), File.join(Dir.pwd, 'data', '.xyz')]
+    ].each do |env_var_value, expected_path|
+      ENV["NETRC"] = env_var_value
+      assert_equal expected_path, Netrc.default_path
+    end
   ensure
     ENV.delete("NETRC")
   end


### PR DESCRIPTION
## Description

This PR changes the logic that handles `NETRC` env var value. According to the canonical [GNU inetutils implementation](https://github.com/guillemj/inetutils/blob/master/ftp/ruserpass.c#L120-L132) the env var value supposed to be used as is without appending any file names. So `/some_dir/abc.xyz` is a correct value and the `abc.xyz` file supposed to be parsed accordingly. To preserve backward compatibility with current behavior I keep appending the default netrc filename for cases when the env var points to a directory (that is incorrect according to `inetutils` implementation). So this implementation can be considered as a superset of the GNU `inetutils` plus some heuristics 😁